### PR TITLE
Create database indices on recently added fields

### DIFF
--- a/pkg/database/model.go
+++ b/pkg/database/model.go
@@ -63,7 +63,7 @@ type Run struct {
 	ExperimentID   int32
 	Experiment     Experiment
 	DeletedTime    sql.NullInt64 `gorm:"type:bigint"`
-	RowNum         RowNum
+	RowNum         RowNum        `gorm:"index"`
 	Params         []Param
 	Tags           []Tag
 	Metrics        []Metric
@@ -110,7 +110,7 @@ type Metric struct {
 	RunID     string  `gorm:"column:run_uuid;not null;primaryKey;index"`
 	Step      int64   `gorm:"default:0;not null;primaryKey"`
 	IsNan     bool    `gorm:"default:false;not null;primaryKey"`
-	Iter      int64
+	Iter      int64   `gorm:"index"`
 }
 
 type LatestMetric struct {


### PR DESCRIPTION
I forgot to ensure the new `runs.row_num` and `metrics.iter` fields were indexed. This update should increase query speed in a few operations.